### PR TITLE
Update Base64ImageProvider to return a new stream in ImageSource

### DIFF
--- a/MauiBase64ImageSample/Base64ImageProvider.cs
+++ b/MauiBase64ImageSample/Base64ImageProvider.cs
@@ -14,11 +14,7 @@ public static class Base64ImageProvider
         try
         {
             var imageBytes = Convert.FromBase64String(Base64Imagestring);
-
-            MemoryStream imageDecodeStream = new(imageBytes);
-
-
-            ImageSource myIs = ImageSource.FromStream(() => imageDecodeStream);
+            var myIs = ImageSource.FromStream(() => new MemoryStream(imageBytes));
             return myIs;
         }
         catch (Exception ex)


### PR DESCRIPTION
ImageSource will close the stream and use the factory method to create new streams when the image is needed again. Since only one stream was held previously, it will be disposed and lead to exceptions on subsequent ImageSource uses